### PR TITLE
add on-visible-change event for modal show or hide/close

### DIFF
--- a/components/modal/Modal.jsx
+++ b/components/modal/Modal.jsx
@@ -75,12 +75,16 @@ export default {
   // static warn: ModalFunc;
   // static warning: ModalFunc;
   // static confirm: ModalFunc;
+  watch: {
+    visible (curVal, oldVal) {
+      this.$emit('on-visible-change', curVal)
+    },
+  },
   methods: {
     handleCancel (e) {
       this.$emit('cancel', e)
       this.$emit('change', false)
     },
-
     handleOk (e) {
       this.$emit('ok', e)
     },


### PR DESCRIPTION
add a event: on-visible-change
when visible of modal to be true or false, this event dispatched with new value of visible.

scene:
  user open a modal with a form, one of the value in form should initialized by calling a REST service.
  then user cancel or confirm the modal.
  next, user reopen the modal, here need a new value by calling the REST service.

SO, add on-visible-change event for this scene.